### PR TITLE
Removing vague line that covers in person activity outside of the Slack

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,6 @@
 
 - Diversity and inclusion make our community strong. We encourage participation from the most varied and diverse backgrounds possible and want to be very clear about where we stand.
 - Our goal is to maintain a safe, helpful and friendly community for everyone, regardless of experience, gender identity and expression, sexual orientation, disability, personal appearance, body size, race, ethnicity, age, religion, nationality, or other defining characteristic.
-- This code and related procedures also apply to unacceptable behavior occurring outside the scope of community activities, in all community venues— online and in-person— as well as in all one-on-one communications, and anywhere such behavior has the potential to adversely affect the safety and well-being of community members.
 
 ## Expected Behavior
 


### PR DESCRIPTION
This line might make sense within the context of a specific event (RubyConf, Code Mash, etc..) but I feel it is overly broad for a community in which we live day to day lives outside of work.

This clause potentially has enforcement issues over minor offenses outside of Slack and outside of work. Person A says Person B did X. How do we prove this? How do we verify this? We should not turn our moderators into judges.

The line: `Intimidation or harassment (online or in-person). Please read the Citizen Code of Conduct for how we interpret harassment.`

Already covers intimidation (threats etc..) as well as harassment in person. 